### PR TITLE
#11. Implementar consulta de historial de notificaciones

### DIFF
--- a/src/client/client.py
+++ b/src/client/client.py
@@ -90,6 +90,7 @@ async def escuchar_servidor(reader: asyncio.StreamReader, cola_respuestas: async
     except Exception as e:
         logger.error(f"Error en la escucha del servidor: {e}")
 
+
 async def loop_menu(writer: asyncio.StreamWriter, nombre_farmacia: str, cola_respuestas: asyncio.Queue, esperando_respuesta: asyncio.Event) -> None:
     """
     Corrutina que gestiona el menú interactivo.
@@ -212,7 +213,12 @@ async def loop_menu(writer: asyncio.StreamWriter, nombre_farmacia: str, cola_res
                     print("  Operación cancelada.")
 
             elif opcion == "6":
-                await enviar_mensaje(writer, {"accion": "ver_notificaciones"})
+                filtrar = await input_async("  ¿Solo notificaciones no leídas? [s/N]: ")
+                solo_no_leidas = filtrar.strip().lower() == "s"
+                await enviar_mensaje(writer, {
+                    "accion": "ver_notificaciones",
+                    "solo_no_leidas": solo_no_leidas
+            })
 
             elif opcion == "7":
                 # Usamos input_entero_positivo porque un umbral de 0 o texto

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -219,9 +219,11 @@ async def manejar_crud(conn, writer: asyncio.StreamWriter, farmacia_id: int, men
             )
 
     elif accion == "ver_notificaciones":
-        resultado = await ver_notificaciones(conn, farmacia_id)
+        solo_no_leidas = mensaje.get("solo_no_leidas", False)
+        resultado = await ver_notificaciones(conn, farmacia_id, solo_no_leidas)
         logger.info(
             f"[farmacia_id={farmacia_id}] ver_notificaciones "
+            f"(solo_no_leidas={solo_no_leidas}) "
             f"→ {len(resultado.get('notificaciones', []))} registros"
         )
         await enviar_mensaje(writer, {"tipo": "respuesta", **resultado})


### PR DESCRIPTION
## Descripción 

La funcionalidad principal fue implementada durante el Issue #19 . Este PR agrega el único punto que faltaba del criterio de aceptación: el filtro por notificaciones no leídas.

**Cambios**: El cliente ahora pregunta al usuario si quiere ver solo las no leídas antes de enviar la solicitud al servidor. El servidor lee ese parámetro y se lo pasa a `ver_notificaciones`. La capa de datos no requirió cambios porque el parámetro `solo_no_leidas` ya existía en el repositorio.

## Issues Relacionados
closes #21 