### PR TITLE
#15. Análisis y refactor del código

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,12 @@
+"""
+Paquete raíz de PharmaNotify.
+
+Estructura interna:
+  shared/          → configuración, logger y protocolo compartidos
+  infrastructure/  → conexiones a servicios externos y repositorios de datos
+  server/          → servidor AsyncIO (TCP + IPC + Redis pub/sub)
+  client/          → cliente CLI de farmacia
+  monitor/         → monitor administrativo (IPC)
+  workers/         → tareas distribuidas de Celery
+  utils/           → utilidades compartidas (input, validación, excepciones)
+"""

--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -1,0 +1,7 @@
+"""
+Paquete del cliente CLI de PharmaNotify.
+
+Módulos:
+  client.py → lógica de conexión, corrutinas de menú y escucha.
+  ui.py     → funciones de presentación visual (menú, resumen de estado).
+"""

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -1,3 +1,16 @@
+"""
+Cliente CLI de PharmaNotify.
+
+Se conecta al servidor por TCP y permite a una farmacia gestionar
+su inventario de medicamentos a través de un menú interactivo.
+Internamente corre dos corrutinas en paralelo:
+  - loop_menu(): captura la entrada del usuario y envía comandos.
+  - escuchar_servidor(): recibe respuestas y notificaciones en tiempo real.
+
+La separación en dos corrutinas permite que las notificaciones de fondo
+(vencimientos, eventos CRUD) lleguen sin bloquear la interacción del usuario.
+"""
+
 import asyncio
 import argparse
 
@@ -314,6 +327,10 @@ async def iniciar_cliente(host: str, puerto: int, nombre_farmacia: str) -> None:
 
 
 def parsear_argumentos():
+    """
+    Procesa los argumentos de línea de comandos del cliente:
+    --host, --puerto del servidor, y --farmacia con el nombre de la farmacia.
+    """
     parser = argparse.ArgumentParser(
         description="PharmaNotify — Cliente CLI de farmacia"
     )

--- a/src/client/ui.py
+++ b/src/client/ui.py
@@ -26,6 +26,9 @@ def mostrar_resumen(resumen: dict) -> None:
 
 
 def mostrar_menu() -> None:
+    """
+    Imprime el menú interactivo del cliente con las opciones disponibles.
+    """
     print("\n+--------------------------------------+")
     print("|           PHARMA NOTIFY              |")
     print("+--------------------------------------+")

--- a/src/infrastructure/__init__.py
+++ b/src/infrastructure/__init__.py
@@ -24,17 +24,20 @@ from src.infrastructure.repositories import (
     actualizar_medicamento,
     eliminar_medicamento,
     guardar_notificacion,
+    ver_notificaciones,
     guardar_notificacion_sync,
     verificar_notificacion_reciente_sync,
+    obtener_medicamentos_proximos_sync,
     limpiar_notificaciones_antiguas_sync,
-    ver_notificaciones,
     crear_farmacia,
     listar_farmacias,
     renombrar_farmacia,
-    desactivar_farmacia,
+    buscar_farmacia_por_nombre,
     activar_farmacia,
+    desactivar_farmacia,
+    configurar_umbral,
     obtener_estadisticas,
-    configurar_umbral
+    obtener_resumen_farmacia
 )
 
 __all__ = [
@@ -47,16 +50,19 @@ __all__ = [
     "buscar_medicamento",
     "actualizar_medicamento",
     "eliminar_medicamento",
-    "ver_notificaciones",
     "guardar_notificacion",
+    "ver_notificaciones",
     "guardar_notificacion_sync",
     "verificar_notificacion_reciente_sync",
+    "obtener_medicamentos_proximos_sync",
     "limpiar_notificaciones_antiguas_sync",
-    "configurar_umbral",
     "crear_farmacia",
     "listar_farmacias",
     "renombrar_farmacia",
-    "desactivar_farmacia",
+    "buscar_farmacia_por_nombre",
     "activar_farmacia",
-    "obtener_estadisticas"
+    "desactivar_farmacia",
+    "configurar_umbral",
+    "obtener_estadisticas",
+    "obtener_resumen_farmacia"
 ]

--- a/src/infrastructure/clients/database.py
+++ b/src/infrastructure/clients/database.py
@@ -1,3 +1,14 @@
+"""
+Clientes de conexión a MariaDB.
+
+Provee dos funciones de conexión según el modelo de ejecución:
+  - get_async_connection(): para el servidor AsyncIO (usa aiomysql)
+  - get_sync_connection(): para los workers de Celery (usa PyMySQL)
+
+Centralizar la creación de conexiones aquí significa que si la BD
+cambia de host, credenciales, o motor, el cambio ocurre en un único lugar.
+"""
+
 import aiomysql
 import pymysql
 from src.shared.config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD

--- a/src/infrastructure/repositories/__init__.py
+++ b/src/infrastructure/repositories/__init__.py
@@ -15,9 +15,13 @@ from src.infrastructure.repositories.medicamentos import (
 
 from src.infrastructure.repositories.notificaciones import (
     guardar_notificacion,
-    guardar_notificacion_sync,
     ver_notificaciones,
+)
+
+from src.infrastructure.repositories.notificaciones_sync import (
+    guardar_notificacion_sync,
     verificar_notificacion_reciente_sync,
+    obtener_medicamentos_proximos_sync,
     limpiar_notificaciones_antiguas_sync
 )
 
@@ -25,10 +29,12 @@ from src.infrastructure.repositories.farmacias import (
     crear_farmacia,
     listar_farmacias,
     renombrar_farmacia,
-    desactivar_farmacia,
+    buscar_farmacia_por_nombre,
     activar_farmacia,
+    desactivar_farmacia,
+    configurar_umbral,
     obtener_estadisticas,
-    configurar_umbral
+    obtener_resumen_farmacia
 )
 
 __all__ = [
@@ -41,12 +47,15 @@ __all__ = [
     "guardar_notificacion_sync",
     "ver_notificaciones",
     "verificar_notificacion_reciente_sync",
+    "obtener_medicamentos_proximos_sync",
     "limpiar_notificaciones_antiguas_sync",
-    "configurar_umbral",
     "crear_farmacia",
     "listar_farmacias",
     "renombrar_farmacia",
-    "desactivar_farmacia",
+    "buscar_farmacia_por_nombre",
     "activar_farmacia",
-    "obtener_estadisticas"
+    "desactivar_farmacia",
+    "configurar_umbral",
+    "obtener_estadisticas",
+    "obtener_resumen_farmacia"
 ]

--- a/src/infrastructure/repositories/farmacias.py
+++ b/src/infrastructure/repositories/farmacias.py
@@ -1,3 +1,12 @@
+"""
+Repositorio de operaciones sobre la tabla 'farmacias'.
+
+Todas las funciones son async porque las consume exclusivamente
+el servidor AsyncIO a través de la capa de infraestructura.
+Encapsula: alta, baja lógica, renombrado, activación, configuración
+de umbral, búsqueda por nombre, estadísticas y resumen de estado.
+"""
+
 async def crear_farmacia(conn, nombre: str) -> dict:
     """
     Da de alta una nueva farmacia en el sistema.
@@ -95,6 +104,69 @@ async def renombrar_farmacia(conn, nombre_actual: str, nombre_nuevo: str) -> dic
     return {"ok": True, "mensaje": f"Farmacia renombrada de '{nombre_actual_norm}' a '{nombre_nuevo_norm}'."}
 
 
+async def buscar_farmacia_por_nombre(conn, nombre: str) -> dict:
+    """
+    Busca una farmacia por nombre normalizado para validar conexiones de clientes.
+    Devuelve la info necesaria para que el servidor decida si aceptar o rechazar
+    la conexión, sin que el servidor tenga que conocer la estructura de la tabla.
+
+    A diferencia de las otras funciones de este repositorio, esta NO filtra
+    por activo = TRUE porque el servidor necesita distinguir tres casos:
+    farmacia no existe, farmacia desactivada, y farmacia activa.
+    """
+    nombre_normalizado = nombre.strip()
+
+    async with conn.cursor() as cursor:
+        await cursor.execute(
+            "SELECT id, nombre, activo FROM farmacias WHERE LOWER(nombre) = LOWER(%s)",
+            (nombre_normalizado,)
+        )
+        fila = await cursor.fetchone()
+
+    if fila is None:
+        return {"ok": False, "encontrada": False}
+
+    return {
+        "ok": True,
+        "encontrada": True,
+        "farmacia_id": fila[0],
+        "nombre": fila[1],
+        "activa": bool(fila[2])
+    }
+
+async def activar_farmacia(conn, nombre: str) -> dict:
+    """
+    Reactiva una farmacia que estaba desactivada (activo = TRUE).
+    Es el espejo exacto de desactivar_farmacia: misma lógica de
+    distinción de casos, dirección opuesta.
+    Si la farmacia no existe, ya estaba activa, o se reactiva ahora,
+    cada caso recibe su propio mensaje.
+    """
+    nombre_norm = nombre.strip()
+
+    async with conn.cursor() as cursor:
+        await cursor.execute(
+            "SELECT id, activo FROM farmacias WHERE LOWER(nombre) = LOWER(%s)",
+            (nombre_norm,)
+        )
+        farmacia = await cursor.fetchone()
+
+        if farmacia is None:
+            return {"ok": False, "mensaje": f"No existe ninguna farmacia con el nombre '{nombre_norm}'."}
+
+        farmacia_id, esta_activa = farmacia
+
+        if esta_activa:
+            return {"ok": False, "mensaje": f"La farmacia '{nombre_norm}' ya estaba activa."}
+
+        await cursor.execute(
+            "UPDATE farmacias SET activo = TRUE WHERE id = %s",
+            (farmacia_id,)
+        )
+
+    return {"ok": True, "farmacia_id": farmacia_id, "mensaje": f"Farmacia '{nombre_norm}' reactivada exitosamente."}
+
+
 async def desactivar_farmacia(conn, nombre: str) -> dict:
     """
     Desactiva lógicamente una farmacia (activo = FALSE).
@@ -130,37 +202,44 @@ async def desactivar_farmacia(conn, nombre: str) -> dict:
     return {"ok": True, "farmacia_id": farmacia_id, "mensaje": f"Farmacia '{nombre_norm}' desactivada."}
 
 
-async def activar_farmacia(conn, nombre: str) -> dict:
+async def configurar_umbral(conn, farmacia_id: int, umbral_dias: int) -> dict:
     """
-    Reactiva una farmacia que estaba desactivada (activo = TRUE).
-    Es el espejo exacto de desactivar_farmacia: misma lógica de
-    distinción de casos, dirección opuesta.
-    Si la farmacia no existe, ya estaba activa, o se reactiva ahora,
-    cada caso recibe su propio mensaje.
+    Actualiza el umbral de días de anticipación para alertas de vencimiento.
+    Separamos la verificación de existencia del update porque MariaDB reporta
+    rowcount = 0 cuando el valor nuevo es igual al actual, lo que haría
+    imposible distinguir entre "farmacia no encontrada" y "valor sin cambios".
     """
-    nombre_norm = nombre.strip()
-
     async with conn.cursor() as cursor:
+
+        # Primero verificamos que la farmacia existe y está activa.
+        # Esta consulta es independiente del valor de umbral_dias,
+        # así que siempre nos dice la verdad sobre si la farmacia existe.
         await cursor.execute(
-            "SELECT id, activo FROM farmacias WHERE LOWER(nombre) = LOWER(%s)",
-            (nombre_norm,)
-        )
-        farmacia = await cursor.fetchone()
-
-        if farmacia is None:
-            return {"ok": False, "mensaje": f"No existe ninguna farmacia con el nombre '{nombre_norm}'."}
-
-        farmacia_id, esta_activa = farmacia
-
-        if esta_activa:
-            return {"ok": False, "mensaje": f"La farmacia '{nombre_norm}' ya estaba activa."}
-
-        await cursor.execute(
-            "UPDATE farmacias SET activo = TRUE WHERE id = %s",
+            "SELECT umbral_dias FROM farmacias WHERE id = %s AND activo = TRUE",
             (farmacia_id,)
         )
+        fila = await cursor.fetchone()
 
-    return {"ok": True, "farmacia_id": farmacia_id, "mensaje": f"Farmacia '{nombre_norm}' reactivada exitosamente."}
+        if fila is None:
+            return {"ok": False, "mensaje": "Farmacia no encontrada o inactiva."}
+
+        umbral_actual = fila[0]
+
+        # Si el valor nuevo es igual al actual, lo informamos amigablemente
+        # en lugar de hacer un UPDATE innecesario.
+        if umbral_actual == umbral_dias:
+            return {
+                "ok": True,
+                "mensaje": f"El umbral ya estaba configurado en {umbral_dias} días. No se realizaron cambios."
+            }
+
+        # Solo llegamos acá si el valor realmente cambió.
+        await cursor.execute(
+            "UPDATE farmacias SET umbral_dias = %s WHERE id = %s AND activo = TRUE",
+            (umbral_dias, farmacia_id)
+        )
+
+    return {"ok": True, "mensaje": f"Umbral actualizado de {umbral_actual} a {umbral_dias} días."}
 
 
 async def obtener_estadisticas(conn) -> dict:
@@ -203,41 +282,50 @@ async def obtener_estadisticas(conn) -> dict:
     }
 
 
-async def configurar_umbral(conn, farmacia_id: int, umbral_dias: int) -> dict:
+async def obtener_resumen_farmacia(conn, farmacia_id: int) -> dict:
     """
-    Actualiza el umbral de días de anticipación para alertas de vencimiento.
-    Separamos la verificación de existencia del update porque MariaDB reporta
-    rowcount = 0 cuando el valor nuevo es igual al actual, lo que haría
-    imposible distinguir entre "farmacia no encontrada" y "valor sin cambios".
+    Consulta la BD y construye un resumen del estado actual de la farmacia.
+    Se envía automáticamente al cliente justo después de que se valida su conexión.
     """
     async with conn.cursor() as cursor:
 
-        # Primero verificamos que la farmacia existe y está activa.
-        # Esta consulta es independiente del valor de umbral_dias,
-        # así que siempre nos dice la verdad sobre si la farmacia existe.
         await cursor.execute(
-            "SELECT umbral_dias FROM farmacias WHERE id = %s AND activo = TRUE",
+            "SELECT COUNT(*) FROM medicamentos WHERE farmacia_id = %s AND activo = TRUE",
             (farmacia_id,)
         )
-        fila = await cursor.fetchone()
+        (total_activos,) = await cursor.fetchone()
 
-        if fila is None:
-            return {"ok": False, "mensaje": "Farmacia no encontrada o inactiva."}
-
-        umbral_actual = fila[0]
-
-        # Si el valor nuevo es igual al actual, lo informamos amigablemente
-        # en lugar de hacer un UPDATE innecesario.
-        if umbral_actual == umbral_dias:
-            return {
-                "ok": True,
-                "mensaje": f"El umbral ya estaba configurado en {umbral_dias} días. No se realizaron cambios."
-            }
-
-        # Solo llegamos acá si el valor realmente cambió.
         await cursor.execute(
-            "UPDATE farmacias SET umbral_dias = %s WHERE id = %s AND activo = TRUE",
-            (umbral_dias, farmacia_id)
+            "SELECT COUNT(*) FROM notificaciones WHERE farmacia_id = %s AND leida = FALSE",
+            (farmacia_id,)
         )
+        (notificaciones_no_leidas,) = await cursor.fetchone()
 
-    return {"ok": True, "mensaje": f"Umbral actualizado de {umbral_actual} a {umbral_dias} días."}
+        # Ahora el filtro es preciso: solo medicamentos desactivados
+        # automáticamente por Celery cuando su fecha de vencimiento pasó.
+        # Los eliminados manualmente por el usuario tienen motivo_baja = 'eliminado_manual'
+        # y no tienen nada que hacer en esta sección del resumen.
+        await cursor.execute(
+            """
+            SELECT nombre, fecha_vencimiento
+            FROM medicamentos
+            WHERE farmacia_id = %s 
+              AND activo = FALSE 
+              AND motivo_baja = 'vencido_automatico'
+            ORDER BY fecha_vencimiento DESC
+            LIMIT 10
+            """,
+            (farmacia_id,)
+        )
+        filas_vencidos = await cursor.fetchall()
+        vencidos_lista = [
+            {"nombre": fila[0], "fecha_vencimiento": str(fila[1])}
+            for fila in filas_vencidos
+        ]
+
+    return {
+        "tipo": "resumen_estado",
+        "medicamentos_activos": total_activos,
+        "notificaciones_no_leidas": notificaciones_no_leidas,
+        "vencidos_mientras_ausente": vencidos_lista
+    }

--- a/src/infrastructure/repositories/medicamentos.py
+++ b/src/infrastructure/repositories/medicamentos.py
@@ -1,3 +1,12 @@
+"""
+Repositorio de operaciones sobre la tabla 'medicamentos'.
+
+Todas las funciones son async porque las consume exclusivamente
+el servidor AsyncIO. Encapsula las operaciones CRUD completas:
+crear, listar, buscar, actualizar y eliminar (eliminación lógica
+con campo motivo_baja para distinguir bajas manuales de automáticas).
+"""
+
 async def crear_medicamento(conn, farmacia_id: int, codigo: str, nombre: str, fecha_vencimiento: str) -> dict:
     """
     Inserta un nuevo medicamento para la farmacia dada.

--- a/src/infrastructure/repositories/notificaciones.py
+++ b/src/infrastructure/repositories/notificaciones.py
@@ -1,3 +1,11 @@
+"""
+Repositorio de notificaciones — operaciones asincrónicas.
+
+Todas las funciones de este módulo son async porque las consume
+exclusivamente el servidor AsyncIO. Usan aiomysql a través de
+la conexión async que les pasa el servidor.
+"""
+
 async def guardar_notificacion(conn, farmacia_id: int, tipo: str, mensaje: str) -> dict:
     """
     Versión async para usar desde el servidor si fuera necesario.
@@ -46,67 +54,3 @@ async def ver_notificaciones(conn, farmacia_id: int, solo_no_leidas: bool = Fals
             for fila in filas
         ]
     }
-
-
-def guardar_notificacion_sync(conn, farmacia_id: int, tipo: str, mensaje: str) -> None:
-    """
-    Versión sync para usar desde los workers de Celery.
-    """
-    with conn.cursor() as cursor:
-        cursor.execute(
-            "INSERT INTO notificaciones (farmacia_id, tipo, mensaje) VALUES (%s, %s, %s)",
-            (farmacia_id, tipo, mensaje)
-        )
-        
-
-def verificar_notificacion_reciente_sync(conn, farmacia_id: int, codigo_medicamento: str) -> bool:
-    """
-    Devuelve True si ya existe una notificación de tipo 'proximo_vencimiento'
-    para este medicamento generada en las últimas 24 horas.
-
-    Usamos LIKE '%codigo%' en el mensaje porque no guardamos el código como
-    campo separado en la tabla notificaciones: está embebido dentro del texto
-    del mensaje.
-
-    Las 24 horas como ventana es una decisión de negocio..
-    """
-    with conn.cursor() as cursor:
-        cursor.execute(
-            """
-            SELECT COUNT(*) FROM notificaciones
-            WHERE farmacia_id = %s
-              AND tipo = 'proximo_vencimiento'
-              AND mensaje LIKE %s
-              AND creado_en >= NOW() - INTERVAL 24 HOUR
-            """,
-            (farmacia_id, f"%{codigo_medicamento}%")
-        )
-        (cantidad,) = cursor.fetchone()
-    return cantidad > 0
-
-def limpiar_notificaciones_antiguas_sync(conn, retention_days: int) -> int:
-    """
-    Elimina físicamente las notificaciones que cumplen dos condiciones:
-      1. Ya fueron leídas (leida = TRUE).
-      2. Tienen más de retention_days días de antigüedad.
-
-    Es la única operación del sistema que hace eliminación física.
-    La justificación es que una notificación leída y antigua ya cumplió
-    su propósito: la farmacia la vio y el período de consulta razonable
-    pasó. Preservarla indefinidamente solo infla la tabla sin valor.
-
-    Las notificaciones no leídas nunca se eliminan porque todavía
-    tienen valor para la farmacia, sin importar su antigüedad.
-
-    Devuelve la cantidad de registros eliminados para el log.
-    """
-    with conn.cursor() as cursor:
-        cursor.execute(
-            """
-            DELETE FROM notificaciones
-            WHERE leida = TRUE
-              AND creado_en < NOW() - INTERVAL %s DAY
-            """,
-            (retention_days,)
-        )
-        return cursor.rowcount

--- a/src/infrastructure/repositories/notificaciones_sync.py
+++ b/src/infrastructure/repositories/notificaciones_sync.py
@@ -1,0 +1,103 @@
+"""
+Repositorio de notificaciones — operaciones sincrónicas.
+
+Todas las funciones de este módulo son sync porque las consumen
+exclusivamente los workers de Celery, que corren en procesos
+separados sin event loop de AsyncIO.
+"""
+
+
+def guardar_notificacion_sync(conn, farmacia_id: int, tipo: str, mensaje: str) -> None:
+    """
+    Persiste una notificación en la BD usando conexión sincrónica.
+    Usada por los workers de Celery después de detectar un evento
+    (CRUD de medicamentos, vencimiento próximo).
+    """
+    with conn.cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO notificaciones (farmacia_id, tipo, mensaje) VALUES (%s, %s, %s)",
+            (farmacia_id, tipo, mensaje)
+        )
+        
+
+def verificar_notificacion_reciente_sync(conn, farmacia_id: int, codigo_medicamento: str) -> bool:
+    """
+    Devuelve True si ya existe una notificación de tipo 'proximo_vencimiento'
+    para este medicamento generada en las últimas 24 horas.
+
+    Usamos LIKE '%codigo%' en el mensaje porque no guardamos el código como
+    campo separado en la tabla notificaciones: está embebido dentro del texto
+    del mensaje.
+
+    Las 24 horas como ventana es una decisión de negocio..
+    """
+    with conn.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT COUNT(*) FROM notificaciones
+            WHERE farmacia_id = %s
+              AND tipo = 'proximo_vencimiento'
+              AND mensaje LIKE %s
+              AND creado_en >= NOW() - INTERVAL 24 HOUR
+            """,
+            (farmacia_id, f"%{codigo_medicamento}%")
+        )
+        (cantidad,) = cursor.fetchone()
+    return cantidad > 0
+
+
+def obtener_medicamentos_proximos_sync(conn) -> list:
+    """
+    Consulta medicamentos activos cuya fecha de vencimiento cae dentro
+    del umbral configurado por cada farmacia.
+
+    El JOIN con farmacias es necesario porque cada farmacia tiene su propio
+    umbral_dias: una farmacia puede querer alertas con 7 días de anticipación
+    y otra con 15. No podemos usar un valor fijo global.
+
+    Filtramos fecha_vencimiento >= CURDATE() para excluir medicamentos ya
+    vencidos, que se manejan por otro mecanismo (desactivación automática).
+
+    Devuelve una lista de tuplas con los datos que necesita
+    verificar_vencimientos para generar las alertas.
+    """
+    with conn.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT
+                m.farmacia_id,
+                m.codigo,
+                m.nombre,
+                m.fecha_vencimiento,
+                f.umbral_dias,
+                DATEDIFF(m.fecha_vencimiento, CURDATE()) AS dias_restantes
+            FROM medicamentos m
+            JOIN farmacias f ON f.id = m.farmacia_id
+            WHERE m.activo = TRUE
+              AND f.activo = TRUE
+              AND m.fecha_vencimiento <= DATE_ADD(CURDATE(), INTERVAL f.umbral_dias DAY)
+              AND m.fecha_vencimiento >= CURDATE()
+            ORDER BY m.fecha_vencimiento ASC
+            """
+        )
+        return cursor.fetchall()
+
+
+def limpiar_notificaciones_antiguas_sync(conn, retention_days: int) -> int:
+    """
+    Elimina físicamente las notificaciones que cumplen dos condiciones:
+      1. Ya fueron leídas (leida = TRUE).
+      2. Tienen más de retention_days días de antigüedad.
+
+    Devuelve la cantidad de registros eliminados para el log.
+    """
+    with conn.cursor() as cursor:
+        cursor.execute(
+            """
+            DELETE FROM notificaciones
+            WHERE leida = TRUE
+              AND creado_en < NOW() - INTERVAL %s DAY
+            """,
+            (retention_days,)
+        )
+        return cursor.rowcount

--- a/src/monitor/__init__.py
+++ b/src/monitor/__init__.py
@@ -1,0 +1,7 @@
+"""
+Paquete del monitor administrativo de PharmaNotify.
+
+Módulos:
+  monitor.py → lógica de conexión IPC y loop de comandos interactivo.
+  ui.py      → funciones de presentación visual (menú, formateo de respuestas).
+"""

--- a/src/monitor/ui.py
+++ b/src/monitor/ui.py
@@ -1,5 +1,3 @@
-# src/monitor/ui.py
-
 """
 Funciones de presentación visual del monitor administrativo.
 
@@ -10,6 +8,9 @@ y viceversa.
 
 
 def mostrar_menu() -> None:
+    """
+    Imprime el menú interactivo del monitor con las opciones de administración.
+    """
     print("\n+------------------------------------------+")
     print("|       PHARMA NOTIFY — MONITOR ADMIN      |")
     print("+------------------------------------------+")

--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -1,0 +1,8 @@
+"""
+Paquete del servidor de PharmaNotify.
+
+Módulo principal:
+  server.py → orquesta las tres corrutinas concurrentes del servidor
+              (TCP, IPC, Redis pub/sub) y despacha operaciones a los
+              repositorios de la capa de infraestructura.
+"""

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -1,3 +1,15 @@
+"""
+Configuración centralizada del sistema PharmaNotify.
+
+Carga las variables de entorno desde el archivo .env y expone
+constantes con valores por defecto para todos los componentes:
+servidor TCP, MariaDB, Redis, Celery, y notificaciones.
+
+Cualquier componente que necesite un valor configurable lo importa
+desde acá, garantizando que exista una única fuente de verdad.
+"""
+
+
 import os
 from dotenv import load_dotenv
 
@@ -42,4 +54,4 @@ VERIFICATION_INTERVAL_SECONDS = int(os.getenv("VERIFICATION_INTERVAL_SECONDS", 6
 # Notificaciones
 # =============================================================================
 DEFAULT_ALERT_THRESHOLD_DAYS = int(os.getenv("DEFAULT_ALERT_THRESHOLD_DAYS", 7)) # Umbral por defecto de días de anticipación para generar alertas de vencimiento
-NOTIFICATION_RETENTION_DAYS = int(os.getenv("NOTIFICATION_RETENTION_DAYS", 30))
+NOTIFICATION_RETENTION_DAYS = int(os.getenv("NOTIFICATION_RETENTION_DAYS", 30)) 

--- a/src/shared/logger.py
+++ b/src/shared/logger.py
@@ -1,4 +1,12 @@
-# Configuración centralizada del logging para todos los componentes del sistema.
+"""
+Configuración centralizada del logging para todos los componentes del sistema.
+
+Provee obtener_logger(), la función que usan todos los componentes
+para crear loggers con el formato estandarizado del sistema.
+El formato incluye timestamp, nivel (INFO/WARNING/ERROR), nombre
+del componente, y el mensaje. Todos los loggers escriben a stdout.
+"""
+
 import logging
 import sys
 

--- a/src/shared/protocol.py
+++ b/src/shared/protocol.py
@@ -1,3 +1,16 @@
+"""
+Protocolo de comunicación TCP con prefijo de longitud.
+
+Define las funciones enviar_mensaje() y recibir_mensaje() que usan
+tanto el cliente como el servidor para intercambiar diccionarios Python
+por TCP. Cada mensaje se serializa como JSON y se antepone un prefijo
+de 4 bytes (big-endian) con la longitud del payload.
+
+Este módulo es la única dependencia compartida entre cliente y servidor
+en cuanto a comunicación. Si el protocolo cambia, se cambia acá y
+ambos extremos se adaptan automáticamente.
+"""
+
 import json
 import struct
 

--- a/src/workers/__init__.py
+++ b/src/workers/__init__.py
@@ -3,10 +3,9 @@ Paquete de workers del sistema PharmaNotify.
 
 Contiene la configuración de Celery (celery_app.py) y las tareas
 distribuidas que se ejecutan en segundo plano (tasks.py):
-  - tarea_de_prueba: verifica que el sistema Celery está operativo.
-  - verificar_vencimientos: detecta medicamentos próximos a vencer (Issue #9).
-  - eliminar_vencidos: desactiva medicamentos expirados automáticamente (Issue #10).
-  - notificar_evento: persiste y publica notificaciones de eventos CRUD (Issue #8).
+  - notificar_evento: persiste y publica notificaciones de eventos CRUD.
+  - verificar_vencimientos: detecta medicamentos próximos a vencer.
+  - limpiar_notificaciones_antiguas: elimina notificaciones leídas antiguas.
 
 La instancia `celery_app` se re-exporta aquí para que Celery la descubra
 automáticamente al usar `-A src.workers` desde la línea de comandos.

--- a/src/workers/celery_app.py
+++ b/src/workers/celery_app.py
@@ -1,3 +1,12 @@
+"""
+Configuración de la instancia Celery y del scheduler Beat.
+
+Define la conexión al broker Redis, el autodiscovery de tareas
+en src.workers.tasks, y la programación de tareas periódicas:
+  - verificar_vencimientos: cada VERIFICATION_INTERVAL_SECONDS segundos.
+  - limpiar_notificaciones_antiguas: una vez por día a las 3 AM.
+"""
+
 from celery import Celery
 from celery.schedules import crontab
 


### PR DESCRIPTION
## Descripción

Revisión exhaustiva del código fuente del proyecto para identificar y corregir problemas de calidad sin alterar el comportamiento externo del sistema. Los cambios se organizan en los tres ejes definidos en el issue.

### Parte 1 - Detección de redundancias

Se identificaron tres puntos donde componentes fuera de la capa de repositorios ejecutaban queries SQL directamente:

- `obtener_resumen_estado()` en `server.py`: 3 queries para construir el resumen de conexión. Movida a `obtener_resumen_farmacia()` en  `farmacias.py`.
- Búsqueda de farmacia en `manejar_cliente()`: un SELECT directo para  validar la conexión. Extraída a `buscar_farmacia_por_nombre()` en  `farmacias.py`.
- Query con JOIN en `verificar_vencimientos()` de `tasks.py`: un SELECT que cruzaba medicamentos con farmacias. Extraída a  `obtener_medicamentos_proximos_sync()` en `notificaciones_sync.py`.

Después de estos cambios, **no existe SQL fuera de la capa de repositorios** en ningún componente del sistema.

### Parte 2 - Verificación de la arquitectura

Se contrastó el código contra el diagrama del sistema y se confirmó que cada componente cumple su rol asignado:

- El servidor actúa como coordinador puro, sin lógica de negocio.
- Los workers son los únicos que usan conexiones sync a la BD.
- Los repositorios son la única puerta de entrada a las tablas.
- El servidor realiza los CRUDs directamente (sin delegarlos a Celery) porque requieren respuesta inmediata al cliente. Solo las  consecuencias asíncronas (notificaciones) se delegan a los workers.

Adicionalmente, se separó `notificaciones.py` en un módulo async (para el servidor) y un módulo sync (`notificaciones_sync.py`, para los workers), reflejando la separación real de modelos de ejecución en el sistema.

### Parte 3 - Consistencia de patrones

- **Normalización de nombres:** se estandarizó el patrón en todo el   sistema. `.strip()` en Python para espacios, `LOWER()` en SQL para   comparación case-insensitive, `.lower()` en Python solo como clave  de diccionarios en memoria.
- **Formato de respuestas:** se verificó que el canal TCP siempre usa   `"tipo"` y el canal IPC siempre usa `"ok"`, sin cruces. Los dos  formatos distintos son intencionales porque los canales tienen   necesidades distintas.
- **Eliminación lógica:** consistente en farmacias y medicamentos.  Física solo en notificaciones antiguas leídas (justificada).

## Limpieza adicional

- Eliminada `tarea_de_prueba` de `tasks.py` (codigo muerto).
- Corregidas comas faltantes en `__all__` de `repositories/__init__.py`  e `infrastructure/__init__.py` que causaban concatenación silenciosa  de strings.
- Agregados docstrings de módulo a los 28 archivos `.py` del proyecto.
- Creados `__init__.py` faltantes con docstrings para `src/`,  `src/client/`, y `src/server/`.
- Agregados docstrings a las 6 funciones que no los tenían.

## Issues Relacionados
closes #29 