### PR TITLE
#17. Separar configuración de host y mejorar errores de conexión del cliente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,28 +1,35 @@
 # Copiá este archivo como .env y completá los valores para tu entorno.
 
 # Servidor TCP
-SERVER_HOST=
-SERVER_PORT=
+# LISTEN: en qué interfaces escucha el servidor.
+#   "" = todas las interfaces, IPv4 e IPv6 (recomendado)
+#   "localhost" = solo conexiones locales
+SERVER_LISTEN_HOST=
+# CONNECT: a dónde se conecta el cliente por defecto.
+#   "localhost" si el servidor corre en la misma máquina.
+#   Una IP específica si el servidor está en otra máquina.
+SERVER_CONNECT_HOST=localhost
+SERVER_PORT=9999
 
 # Unix Domain Socket para el monitor (IPC)
 MONITOR_SOCKET_PATH=/tmp/pharma_monitor.sock
 
 # MariaDB
-DB_HOST=
-DB_PORT=
-DB_NAME=
-DB_USER=
-DB_PASSWORD=
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=pharma_db
+DB_USER=pharma_user
+DB_PASSWORD=pharma_pass
 
 # Redis
-REDIS_HOST=
-REDIS_PORT=
-REDIS_DB=
-REDIS_NOTIFICATIONS_CHANNEL=
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_DB=0
+REDIS_NOTIFICATIONS_CHANNEL=pharma:notifications
 
 # Celery
-VERIFICATION_INTERVAL_SECONDS=
+VERIFICATION_INTERVAL_SECONDS=60
 
 # Notificaciones
-DEFAULT_ALERT_THRESHOLD_DAYS=
-NOTIFICATION_RETENTION_DAYS=
+DEFAULT_ALERT_THRESHOLD_DAYS=7
+NOTIFICATION_RETENTION_DAYS=30

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -15,7 +15,7 @@ import asyncio
 import argparse
 
 from src.shared import (
-    SERVER_HOST, SERVER_PORT,
+    SERVER_CONNECT_HOST, SERVER_PORT,
     enviar_mensaje, recibir_mensaje,
     obtener_logger
 )
@@ -278,7 +278,13 @@ async def iniciar_cliente(host: str, puerto: int, nombre_farmacia: str) -> None:
     try:
         reader, writer = await asyncio.open_connection(host, puerto)
     except ConnectionRefusedError:
-        print("No se pudo conectar al servidor. ¿Está corriendo?")
+        print(f"La conexión a {host}:{puerto} fue rechazada. ¿Está corriendo el servidor?")
+        return
+    except OSError as e:
+        print(f"No se pudo conectar a {host}:{puerto} — {e}")
+        return
+    except TimeoutError:
+        print(f"La conexión a {host}:{puerto} expiró. Verificá que la dirección sea correcta y que el servidor esté accesible.")
         return
 
     # Handshake: enviamos el nombre de farmacia al servidor
@@ -336,8 +342,8 @@ def parsear_argumentos():
     )
     parser.add_argument(
         "--host",
-        default=SERVER_HOST,
-        help=f"Host del servidor (default: {SERVER_HOST})"
+        default=SERVER_CONNECT_HOST,
+        help=f"Host del servidor (default: {SERVER_CONNECT_HOST})"
     )
     parser.add_argument(
         "--puerto",

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -20,7 +20,7 @@ import json
 import os
 
 from src.shared import (
-    SERVER_HOST, SERVER_PORT,
+    SERVER_LISTEN_HOST, SERVER_PORT,
     REDIS_NOTIFICATIONS_CHANNEL,
     MONITOR_SOCKET_PATH,
     enviar_mensaje, recibir_mensaje,
@@ -554,8 +554,8 @@ def parsear_argumentos():
     )
     parser.add_argument(
         "--host",
-        default=SERVER_HOST,
-        help=f"Host donde escuchar conexiones (default: {SERVER_HOST})"
+        default=SERVER_LISTEN_HOST,
+        help=f"Host donde escuchar conexiones (default: todas las interfaces)"
     )
     parser.add_argument(
         "--puerto",

--- a/src/shared/__init__.py
+++ b/src/shared/__init__.py
@@ -4,7 +4,8 @@ Módulo compartido con configuraciones y utilidades usadas por todos los compone
 
 # Exponemos las configuraciones más usadas
 from .config import (
-    SERVER_HOST,
+    SERVER_LISTEN_HOST,
+    SERVER_CONNECT_HOST,
     SERVER_PORT,
     MONITOR_SOCKET_PATH,
     DB_HOST,
@@ -29,7 +30,7 @@ from .protocol import (
 )
 
 __all__ = [
-    'SERVER_HOST', 'SERVER_PORT',
+    'SERVER_LISTEN_HOST', 'SERVER_CONNECT_HOST', 'SERVER_PORT',
     'MONITOR_SOCKET_PATH',
     'DB_HOST', 'DB_PORT', 'DB_NAME', 'DB_USER', 'DB_PASSWORD',
     'REDIS_HOST', 'REDIS_PORT', 'REDIS_DB', 'REDIS_NOTIFICATIONS_CHANNEL',

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -20,7 +20,15 @@ load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), '..', '.env'))
 # =============================================================================
 # Servidor TCP
 # =============================================================================
-SERVER_HOST = os.getenv("SERVER_HOST", "")
+
+# Host donde el servidor escucha conexiones.
+# "" significa "todas las interfaces" (se convierte a None para asyncio).
+SERVER_LISTEN_HOST = os.getenv("SERVER_LISTEN_HOST", "")
+
+# Host al que el cliente se conecta por defecto.
+# "localhost" es el caso más común: servidor y cliente en la misma máquina.
+# Se puede sobreescribir con --host al ejecutar el cliente.
+SERVER_CONNECT_HOST = os.getenv("SERVER_CONNECT_HOST", "localhost")
 SERVER_PORT  = int(os.getenv("SERVER_PORT", 9999))  # int() porque getenv devuelve strings
 
 MONITOR_SOCKET_PATH = os.getenv("MONITOR_SOCKET_PATH", "/tmp/pharma_monitor.sock")


### PR DESCRIPTION
## Descripción

Corrección de un problema introducido por el fix de dual-stack IPv4/IPv6: el cliente dejó de funcionar sin --host porque compartía la misma constante SERVER_HOST que el servidor, cuyo default cambió a "" (string vacía).

## Solución

Se separó SERVER_HOST en dos constantes con defaults independientes:
  - SERVER_LISTEN_HOST = "" → usado por server.py
  - SERVER_CONNECT_HOST = "localhost" → usado por client.py

Ambas son configurables por variable de entorno, lo que permite que en un despliegue real el cliente apunte a la IP del servidor sin modificar el código.

Además se amplió el manejo de errores en iniciar_cliente() paraque los fallos de conexión (IP inválida, host inalcanzable, conexión rechazada) muestren mensajes claros en lugar de tracebacks.

## Verificación

- Servidor escucha en todas las interfaces (verificado con netstat).
- Cliente sin --host se conecta a localhost correctamente.
- Cliente con --host <ip> se conecta desde otra máquina.
- Cliente con IP incorrecta muestra mensaje de error claro.

## Issues Relacionados
closes #33 