### PR TITLE
#18. Integración con Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/__pycache__/
+**/*.pyc
+.venv/
+venv/
+.env
+.git/
+docs/

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ DB_PORT=3306
 DB_NAME=pharma_db
 DB_USER=pharma_user
 DB_PASSWORD=pharma_pass
+# Contraseña del usuario root de MariaDB.
+# Solo la usa el contenedor Docker al inicializarse por primera vez.
+# Tu código Python nunca la lee — por eso no existe en config.py.
+DB_ROOT_PASSWORD=root_pharma_pass
 
 # Redis
 REDIS_HOST=localhost

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# requirements.txt va primero para aprovechar el cache de Docker.
+# Si solo cambiás código Python, no se reinstalan las dependencias.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Recién acá copiamos el código, después del install.
+COPY . .
+
+# Cada servicio define su propio comando en docker-compose.yml.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,124 @@
+services:
+
+  mariadb:
+    image: mariadb:11
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-root_pharma_pass}
+      MYSQL_DATABASE: ${DB_NAME:-pharma_db}
+      MYSQL_USER: ${DB_USER:-pharma_user}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-pharma_pass}
+    volumes:
+      - pharma_db_data:/var/lib/mysql
+      - ./docker/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro  # corregido
+    healthcheck:
+      test: ["CMD", "mariadb-admin", "ping", "-h", "localhost",
+            "-u", "${DB_USER:-pharma_user}", "-p${DB_PASSWORD:-pharma_pass}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  server:
+    build: .
+    restart: unless-stopped
+    command: python -m src.server.server
+    environment:
+      DB_HOST: mariadb
+      REDIS_HOST: redis
+      SERVER_LISTEN_HOST: "0.0.0.0"
+      SERVER_PORT: ${SERVER_PORT:-9999}
+      DB_PORT: 3306
+      DB_NAME: ${DB_NAME:-pharma_db}
+      DB_USER: ${DB_USER:-pharma_user}
+      DB_PASSWORD: ${DB_PASSWORD:-pharma_pass}
+      REDIS_PORT: 6379
+      REDIS_DB: 0
+      REDIS_NOTIFICATIONS_CHANNEL: ${REDIS_NOTIFICATIONS_CHANNEL:-pharma:notifications}
+      VERIFICATION_INTERVAL_SECONDS: ${VERIFICATION_INTERVAL_SECONDS:-60}
+      DEFAULT_ALERT_THRESHOLD_DAYS: ${DEFAULT_ALERT_THRESHOLD_DAYS:-7}
+      NOTIFICATION_RETENTION_DAYS: ${NOTIFICATION_RETENTION_DAYS:-30}
+      MONITOR_SOCKET_PATH: /sockets/pharma_monitor.sock
+    ports:
+      - "${SERVER_PORT:-9999}:9999"
+    volumes:
+      - pharma_sockets:/sockets
+    depends_on:
+      mariadb:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  celery-worker:
+    build: .
+    restart: unless-stopped
+    command: celery -A src.workers.celery_app worker --loglevel=info
+    environment:
+      DB_HOST: mariadb
+      REDIS_HOST: redis
+      DB_PORT: ${DB_PORT:-3306}
+      DB_NAME: ${DB_NAME:-pharma_db}
+      DB_USER: ${DB_USER:-pharma_user}
+      DB_PASSWORD: ${DB_PASSWORD:-pharma_pass}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      REDIS_DB: ${REDIS_DB:-0}
+      REDIS_NOTIFICATIONS_CHANNEL: ${REDIS_NOTIFICATIONS_CHANNEL:-pharma:notifications}
+      VERIFICATION_INTERVAL_SECONDS: ${VERIFICATION_INTERVAL_SECONDS:-60}
+      DEFAULT_ALERT_THRESHOLD_DAYS: ${DEFAULT_ALERT_THRESHOLD_DAYS:-7}
+      NOTIFICATION_RETENTION_DAYS: ${NOTIFICATION_RETENTION_DAYS:-30}
+    depends_on:
+      mariadb:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  celery-beat:
+    build: .
+    restart: unless-stopped
+    command: celery -A src.workers.celery_app beat --loglevel=info
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_DB: 0
+      VERIFICATION_INTERVAL_SECONDS: ${VERIFICATION_INTERVAL_SECONDS:-60}
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  monitor:
+    build: .
+    profiles: ["admin"]
+    command: python -m src.monitor.monitor
+    environment:
+      MONITOR_SOCKET_PATH: /sockets/pharma_monitor.sock
+    volumes:
+      - pharma_sockets:/sockets
+    stdin_open: true
+    tty: true
+    depends_on:
+      - server
+
+  client:
+    build: .
+    profiles: ["client"]
+    entrypoint: python -m src.client.client
+    stdin_open: true
+    tty: true
+    environment:
+      SERVER_CONNECT_HOST: server
+      SERVER_PORT: ${SERVER_PORT:-9999}
+    depends_on:
+      - server
+
+volumes:
+  pharma_db_data:
+  pharma_sockets:

--- a/docker/schema.sql
+++ b/docker/schema.sql
@@ -1,0 +1,56 @@
+-- =============================================================================
+-- docker/init_db.sql
+--
+-- Inicialización de tablas para PharmaNotify.
+--
+-- Este archivo es ejecutado automáticamente por el contenedor de MariaDB
+-- la PRIMERA vez que arranca con un volumen vacío, gracias al mecanismo
+-- de /docker-entrypoint-initdb.d/. Si el volumen ya tiene datos (es decir,
+-- ya se inicializó antes), este script NO se vuelve a ejecutar.
+--
+-- El usuario y la base de datos ya fueron creados por las variables de entorno
+-- MYSQL_DATABASE, MYSQL_USER y MYSQL_PASSWORD definidas en docker-compose.yml.
+-- Este script solo necesita seleccionar esa base de datos y crear las tablas.
+-- =============================================================================
+
+USE pharma_db;
+
+-- -----------------------------------------------------------------------------
+-- Tabla: farmacias
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS farmacias (
+    id          INT AUTO_INCREMENT PRIMARY KEY,
+    nombre      VARCHAR(100) NOT NULL UNIQUE,
+    umbral_dias INT NOT NULL DEFAULT 7,
+    activo      BOOLEAN NOT NULL DEFAULT TRUE,
+    creado_en   DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- -----------------------------------------------------------------------------
+-- Tabla: medicamentos
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS medicamentos (
+    id                INT AUTO_INCREMENT PRIMARY KEY,
+    farmacia_id       INT NOT NULL,
+    codigo            VARCHAR(50) NOT NULL,
+    nombre            VARCHAR(100) NOT NULL,
+    fecha_vencimiento DATE NOT NULL,
+    activo            BOOLEAN DEFAULT TRUE,
+    motivo_baja       ENUM('eliminado_manual', 'vencido_automatico') DEFAULT NULL,
+    creado_en         TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (farmacia_id) REFERENCES farmacias(id),
+    UNIQUE (farmacia_id, codigo)
+);
+
+-- -----------------------------------------------------------------------------
+-- Tabla: notificaciones
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS notificaciones (
+    id          INT AUTO_INCREMENT PRIMARY KEY,
+    farmacia_id INT NOT NULL,
+    tipo        VARCHAR(50) NOT NULL,
+    mensaje     TEXT NOT NULL,
+    leida       BOOLEAN NOT NULL DEFAULT FALSE,
+    creado_en   DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (farmacia_id) REFERENCES farmacias(id)
+);


### PR DESCRIPTION
## Descripción

Agrega la configuración de Docker necesaria para levantar el sistema completo con un único comando, eliminando la necesidad de instalar y configurar manualmente MariaDB, Redis y las dependencias Python.

## Archivos agregados

- `Dockerfile`: imagen base Python 3.12-slim compartida por todos los servicios del sistema (servidor, workers, cliente y monitor).
- `.dockerignore`: excluye del contexto de build los archivos innecesarios  como __pycache__, .env y .venv.
- `docker-compose.yml`: define y orquesta los 7 servicios del sistema  (mariadb, redis, server, celery-worker, celery-beat, monitor, client).
- `docker/schema.sql`: inicialización automática de tablas aprovechando el mecanismo de /docker-entrypoint-initdb.d/ de la imagen oficial de MariaDB.

## Archivos modificados

- `.env` y `.env.example`: se agrega `DB_ROOT_PASSWORD`, única variable nueva  requerida por el contenedor de MariaDB para su inicialización.

## Decisiones de diseño destacadas

El cliente y el monitor se definen como servicios con `profiles` para que no arranquen automáticamente con `docker compose up`, ya que son herramientas interactivas que se invocan manualmente con `docker compose run --rm`.

El Unix Domain Socket entre el servidor y el monitor se resuelve mediante un volumen compartido (`pharma_sockets`) montado en `/sockets` en ambos contenedores, replicando en Docker el comportamiento que tiene en el entorno
local con el sistema de archivos del host.

Los healthchecks en `mariadb` y `redis` usan `condition: service_healthy` en los `depends_on` para garantizar que el servidor y los workers no intenten conectarse antes de que la infraestructura esté realmente lista.

## Cómo probarlo

Levantar el sistema completo: `docker compose up -d`

Abrir el monitor administrativo: `docker compose run --rm monitor`

Conectar un cliente de farmacia: `docker compose run --rm client --farmacia "Nombre de la farmacia"` (`--host "IP"`  es opcional)

Verificar persistencia de datos: `docker compose down && docker compose up -d`  (los datos deben sobrevivir al reinicio)

## Issue Relacionado
closes #35 